### PR TITLE
外部リンク削除

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
       "android",
       "web"
     ],
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "splash": {
@@ -24,12 +24,13 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.dank.thermometer.app",
-      "buildNumber": "1.0.0"
+      "buildNumber": "1.0.1"
     },
     "android": {
       "package": "com.dank.thermometer.app",
       "permissions": [],
-      "versionCode": 1
+      "versionCode": 2,
+      "versionName": "1.0.1"
     },
     "packagerOpts": {
       "config": "metro.config.js",

--- a/src/components/header.vue
+++ b/src/components/header.vue
@@ -4,29 +4,9 @@
     <nb-body class="header-body">
       <nb-title class="header-title">簡単自己診断</nb-title>
     </nb-body>
-    <nb-right class="header-right">
-      <nb-button transparent>
-        <nb-icon class="medical-icon" type="FontAwesome5" name="hospital-alt" :on-press="openLink" />
-      </nb-button>
-    </nb-right>
+    <nb-right class="header-right" />
   </nb-header>
 </template>
-
-<script>
-import { Linking } from "react-native";
-
-export default {
-  methods: {
-      openLink: function() {
-        Linking
-          .openURL("https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/kenkou_iryou/dengue_fever_qa_00001.html")
-          .catch(
-            err => console.error('URLを開けませんでした。', err)
-          );
-      }
-  },
-};
-</script>
 
 <style>
 .header {
@@ -43,13 +23,9 @@ export default {
   flex: 5;
   align-items: center;
 }
+
 .header-title {
   color: black;
   font-weight: bold;
-}
-
-.medical-icon {
-  color: black;
-  font-size: 20;
 }
 </style>


### PR DESCRIPTION
# What
厚労省の新型コロナ情報まとめへのリンクを削除する。

# Why
iOSの審査で修正対象になったため。